### PR TITLE
Move from "rebar3 edoc" to "rebar3_ex_doc"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         id: setup-beam
         with:
           otp-version: ${{matrix.otp_vsn}}
-          rebar3-version: '3.16'
+          rebar3-version: '3.18'
       - name: restore _build
         uses: actions/cache@v2
         with:
@@ -33,3 +33,5 @@ jobs:
           path: ~/.cache/rebar3
           key: rebar3-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
       - run: make version
+      - run: make ex_doc-dry
+        if: ${{matrix.otp_vsn >= 24}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .rebar3
 _build
+doc
 erl_crash.dump
 log
 rebar3.crashdump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `rebar3_hank [Paulo Oliveira]
+- `rebar3_hank` [Paulo Oliveira]
+- `rebar3_ex_doc` + `make ex_doc-dry` [Paulo Oliveira]
 
 ### Changed
 
 - CI container approach to `setup-beam` with cache [Paulo Oliveira]
+- `edoc`-based doc. to `ex_doc`-based doc. [Paulo Oliveira]
 
 ## [1.1.0] - 2021-03-04
 

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ SHELL := bash
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
-version: upgrade clean compile check test edoc
+version: upgrade clean compile check test
 .PHONY: version
 
-upgrade: upgrade-rebar3_lint upgrade-rebar3_hex upgrade-rebar3_hank
-	@rebar3 do unlock,upgrade
+upgrade: upgrade-rebar3_lint upgrade-rebar3_hex upgrade-rebar3_hank upgrade-rebar3_ex_doc
+	@rebar3 do unlock --all, upgrade --all
 .PHONY: upgrade
 
 upgrade-rebar3_lint:
@@ -23,6 +23,10 @@ upgrade-rebar3_hex:
 upgrade-rebar3_hank:
 	@rebar3 plugins upgrade rebar3_hank
 .PHONY: upgrade-rebar3_hank
+
+upgrade-rebar3_ex_doc:
+	@rebar3 plugins upgrade rebar3_ex_doc
+.PHONY: upgrade-rebar3_ex_doc
 
 clean:
 	@rebar3 clean -a
@@ -55,6 +59,6 @@ test:
 .NOTPARALLEL: test
 .PHONY: test
 
-edoc:
-	@rebar3 edoc
-.PHONY: edoc
+ex_doc-dry:
+	@rebar3 hex publish docs --dry-run
+.PHONY: ex_doc-dry

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-!overview.edoc

--- a/rebar.config
+++ b/rebar.config
@@ -16,6 +16,7 @@
 {deps, []}.
 
 {project_plugins, [
+    rebar3_ex_doc,
     rebar3_hank,
     rebar3_hex,
     rebar3_lint
@@ -64,9 +65,18 @@
     ]}
 ]}.
 
-%% == EDoc ==
+%% == ex_doc ==
 
-{edoc_opts, [
-    {includes, ["src"]},
-    {preprocess, true}
+{ex_doc, [
+    {extras, [
+        {'README.md', #{ title => <<"Overview">> }},
+        {'CHANGELOG.md', #{ title => <<"Changelog">> }},
+        {'LICENSE', #{ title => <<"License">> }}
+    ]},
+    {main, [<<"readme">>]}
+]}.
+{hex, [
+    {doc, #{
+        provider => ex_doc
+    }}
 ]}.


### PR DESCRIPTION
I'm aware this implies Erlang/OTP 24+ and `rebar3` 3.18+ (because of `--all`) but I call it "the price of embracing innovation in technology and user experience."